### PR TITLE
Extensions of Query for selecting various columns and Joins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .crossref-*
 .local-*
 local-*
+Local_*
 !.content.xml
 # IntelliJ
 .idea

--- a/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
+++ b/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
@@ -226,7 +226,8 @@ public class QueryConditionDsl {
         }
 
         /**
-         * The selected node contains a property with the search expression.
+         * The selected node contains a property with the search expression. You might want to
+         * {@link Query#orderBy(String)} {@link org.apache.jackrabbit.JcrConstants#JCR_SCORE} {@link Query#descending()}.
          *
          * @param fulltextSearchExpression The fulltext search expression. A term not preceded with “-” (minus sign) is
          *                                 satisfied only if the value contains that term. A term preceded with “-”
@@ -241,7 +242,8 @@ public class QueryConditionDsl {
         }
 
         /**
-         * The selected node contains a property with the search expression.
+         * The selected node contains a property with the search expression. You might want to
+         * {@link Query#orderBy(String)} {@link org.apache.jackrabbit.JcrConstants#JCR_SCORE} {@link Query#descending()}.
          *
          * @param fulltextSearchExpression The fulltext search expression. A term not preceded with “-” (minus sign) is
          *                                 satisfied only if the value contains that term. A term preceded with “-”

--- a/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
+++ b/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
@@ -21,10 +21,9 @@ import static org.apache.jackrabbit.JcrConstants.JCR_FROZENPRIMARYTYPE;
 import static org.apache.jackrabbit.JcrConstants.JCR_FROZENUUID;
 
 /**
- * Domain specific language to create the {@link Query}s conditions in fluent API style.
- * It closely resembles the constraintStart from the JCR-SQL2 language, except that we use casts as needed but we don't
- * expose this construct explicitly.
- * This immediately creates the needed JCR SQL2-representation.
+ * Domain specific language to create the {@link Query}s conditions in fluent API style. It closely resembles the
+ * constraintStart from the JCR-SQL2 language, except that we use casts as needed but we don't expose this construct
+ * explicitly. This immediately creates the needed JCR SQL2-representation.
  * <p>
  * <p> The general rule is that a complete SQL2 word gets a space appended.
  *
@@ -143,7 +142,13 @@ public class QueryConditionDsl {
             return comparisonOperator;
         }
 
-        /** Starts a comparison of the JCR name of the node to something. */
+        /**
+         * Starts a comparison of the JCR name of the node to something.
+         * <p>
+         * Limitation: this won't work right on the topmost versioned node (often jcr:content) since that is renamed to
+         * jcr:frozenNode in the version storage. Please consider using {@link Query#element} if you make a simple
+         * equality comparison, which can take this into account.
+         */
         public ComparisonOperator name() {
             append("NAME(n) ");
             return comparisonOperator;
@@ -152,6 +157,10 @@ public class QueryConditionDsl {
         /**
          * Starts a comparison of the JCR local name (i.e., without the namespace) of a property of the node to
          * something.
+         * <p>
+         * Limitation: this won't work right on the topmost versioned node (often jcr:content) since that is renamed to
+         * jcr:frozenNode in the version storage. Please consider using {@link Query#element} if you make a simple
+         * equality comparison, which can take this into account.
          */
         public ComparisonOperator localName() {
             append("LOCALNAME(n) ");
@@ -226,8 +235,8 @@ public class QueryConditionDsl {
         }
 
         /**
-         * The selected node contains a property with the search expression. You might want to
-         * {@link Query#orderBy(String)} {@link org.apache.jackrabbit.JcrConstants#JCR_SCORE} {@link Query#descending()}.
+         * The selected node contains a property with the search expression. You might want to {@link
+         * Query#orderBy(String)} {@link org.apache.jackrabbit.JcrConstants#JCR_SCORE} {@link Query#descending()}.
          *
          * @param fulltextSearchExpression The fulltext search expression. A term not preceded with “-” (minus sign) is
          *                                 satisfied only if the value contains that term. A term preceded with “-”
@@ -242,8 +251,8 @@ public class QueryConditionDsl {
         }
 
         /**
-         * The selected node contains a property with the search expression. You might want to
-         * {@link Query#orderBy(String)} {@link org.apache.jackrabbit.JcrConstants#JCR_SCORE} {@link Query#descending()}.
+         * The selected node contains a property with the search expression. You might want to {@link
+         * Query#orderBy(String)} {@link org.apache.jackrabbit.JcrConstants#JCR_SCORE} {@link Query#descending()}.
          *
          * @param fulltextSearchExpression The fulltext search expression. A term not preceded with “-” (minus sign) is
          *                                 satisfied only if the value contains that term. A term preceded with “-”
@@ -269,7 +278,7 @@ public class QueryConditionDsl {
             if (null == values || values.isEmpty()) return isNull(property);
             QueryConditionBuilder cond = this.startGroup();
             QueryCondition res = null;
-            for(String value: values) {
+            for (String value : values) {
                 if (null != res) cond = res.or();
                 res = cond.property(property).eq().val(value);
             }

--- a/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
+++ b/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
@@ -28,6 +28,7 @@ import static org.apache.jackrabbit.JcrConstants.JCR_FROZENUUID;
  * <p>
  * <p> The general rule is that a complete SQL2 word gets a space appended.
  *
+ * @author Hans-Peter Stoerr
  * @see "http://www.h2database.com/jcr/grammar.html#condition"
  * @see "https://docs.adobe.com/docs/en/spec/jcr/2.0/6_Query.html"
  */
@@ -113,7 +114,7 @@ public class QueryConditionDsl {
     /** Inserts a binding variable into the SQL and saves the value. */
     protected QueryConditionDsl appendValue(Object value) {
         if (null == value) throw new IllegalArgumentException("Argument value is null - please use isNull instead.");
-        String bindingVariable = "val" + nextBindingVarNumber;
+        String bindingVariable = selector + "val" + nextBindingVarNumber;
         nextBindingVarNumber++;
         bindingVariables.put(bindingVariable, value);
         append("$").append(bindingVariable).append(" ");

--- a/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
+++ b/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryConditionDsl.java
@@ -21,7 +21,7 @@ import static org.apache.jackrabbit.JcrConstants.JCR_FROZENPRIMARYTYPE;
 import static org.apache.jackrabbit.JcrConstants.JCR_FROZENUUID;
 
 /**
- * Domain specific language to create the {@link Query}s conditions.
+ * Domain specific language to create the {@link Query}s conditions in fluent API style.
  * It closely resembles the constraintStart from the JCR-SQL2 language, except that we use casts as needed but we don't
  * expose this construct explicitly.
  * This immediately creates the needed JCR SQL2-representation.
@@ -48,7 +48,7 @@ public class QueryConditionDsl {
 
     private final ComparisonStart comparisonStart = new ComparisonStart();
     private final QueryCondition queryCondition = new QueryCondition();
-    private final ConstraintStart constraintStart = new ConstraintStart();
+    private final QueryConditionBuilder constraintStart = new QueryConditionBuilder();
     private final ComparisonOperator comparisonOperator = new ComparisonOperator();
     private final ConditionStaticValue conditionStaticValue = new ConditionStaticValue();
 
@@ -58,7 +58,7 @@ public class QueryConditionDsl {
     }
 
     /** Entry point: start building a queryCondition. */
-    public static ConstraintStart builder() {
+    public static QueryConditionBuilder builder() {
         return new QueryConditionDsl().constraintStart;
     }
 
@@ -180,17 +180,17 @@ public class QueryConditionDsl {
         }
     }
 
-    /** Start of a constraintStart with a queryCondition. */
-    public class ConstraintStart extends ComparisonStart {
+    /** Builder for a {@link QueryCondition} in fluent API style. Now we start a constraint with a queryCondition. */
+    public class QueryConditionBuilder extends ComparisonStart {
         /** Starts a group of conditions with an opening parenthesis. */
-        public ConstraintStart startGroup() {
+        public QueryConditionBuilder startGroup() {
             append("( ");
             parenthesesNestingLevel++;
             return constraintStart;
         }
 
         /** Negates the following constraintStart. */
-        public ConstraintStart not() {
+        public QueryConditionBuilder not() {
             append("NOT ");
             return this;
         }
@@ -267,7 +267,7 @@ public class QueryConditionDsl {
         /** The selected node's property is one of the given values. (Extension over JCR-SQL2). */
         public QueryCondition in(String property, Collection<String> values) {
             if (null == values || values.isEmpty()) return isNull(property);
-            ConstraintStart cond = this.startGroup();
+            QueryConditionBuilder cond = this.startGroup();
             QueryCondition res = null;
             for(String value: values) {
                 if (null != res) cond = res.or();
@@ -389,12 +389,12 @@ public class QueryConditionDsl {
      * be used or extended with AND, OR, or closing parenthesis.
      */
     public class QueryCondition {
-        public ConstraintStart and() {
+        public QueryConditionBuilder and() {
             append("AND ");
             return constraintStart;
         }
 
-        public ConstraintStart or() {
+        public QueryConditionBuilder or() {
             append("OR ");
             return constraintStart;
         }

--- a/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryValueMap.java
+++ b/services/staging/src/main/java/com/composum/sling/platform/staging/query/QueryValueMap.java
@@ -1,0 +1,91 @@
+package com.composum.sling.platform.staging.query;
+
+import com.composum.sling.core.util.PropertyUtil;
+import org.apache.commons.lang3.Validate;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Row;
+import java.util.*;
+
+/**
+ * Encapsulates the result of a query for specific properties and pseudo-properties. This contains only the queried
+ * subset of properties of the queried resource. The {@link Map} functionality gives the entries with their default Java
+ * types.
+ *
+ * @see Query#selectAndExecute(String...)
+ */
+public class QueryValueMap extends AbstractMap<String, Object> implements ValueMap {
+
+    private final Query query;
+    private final Row row;
+    private final List<String> columns;
+    private Resource resource;
+    private Map<String, Object> entries;
+
+    QueryValueMap(Query query, Row row, String... columns) {
+        this.query = query;
+        this.row = row;
+        this.columns = Arrays.asList(columns);
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        if (entries == null) {
+            entries = new LinkedHashMap<>();
+            for (String column : columns) {
+                Object value = get(column, Object.class);
+                if (null != value) entries.put(column, value);
+            }
+        }
+        return entries.entrySet();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException when a {@link RepositoryException} occurs
+     */
+    @CheckForNull
+    @Override
+    public <T> T get(@Nonnull String name, @Nonnull Class<T> type) throws IllegalArgumentException {
+        if (!columns.contains(name))
+            throw new IllegalArgumentException("Trying to access column " + name + " that was not selected.");
+        String columnname = "n." + name;
+        if (Query.COLUMN_EXCERPT.equals(name)) columnname = name;
+
+        if (Query.COLUMN_PATH.equals(name)) {
+            Validate.isTrue(String.class.equals(type) || Object.class.equals(type),
+                    "For " + name + " only type String is supported.");
+            String path = query.getString(row, "n.jcr:path");
+            if (path.startsWith("/jcr:system/jcr:versionStorage") && null != query.releasedLabel && !query.path
+                    .startsWith("/jcr:system/jcr:versionStorage")) {
+                // create real historical path for something contained in a release
+                String originalPath = query.getString(row, "query:originalPath");
+                path = originalPath + path.substring(path.indexOf("jcr:frozenNode") + "jcr:frozenNode".length());
+            }
+            return type.cast(path);
+        }
+
+        try {
+            return PropertyUtil.readValue(row.getValue(columnname), type);
+        } catch (RepositoryException e) {
+            throw new IllegalArgumentException("Could not select " + name, e);
+        }
+    }
+
+    @Override
+    public <T> T get(@Nonnull String name, T defaultValue) {
+        T realValue = get(name, PropertyUtil.getType(defaultValue));
+        return null != realValue ? realValue : defaultValue;
+    }
+
+    /** Returns the found resource the values are from. */
+    public Resource getResource() {
+        return resource = null == resource ? query.getResource(row) : resource;
+    }
+
+}

--- a/services/staging/src/main/java/com/composum/sling/platform/staging/query/ValueComparatorFactory.java
+++ b/services/staging/src/main/java/com/composum/sling/platform/staging/query/ValueComparatorFactory.java
@@ -1,23 +1,19 @@
 package com.composum.sling.platform.staging.query;
 
-import org.apache.commons.collections4.ComparatorUtils;
-import org.apache.commons.lang3.exception.ContextedRuntimeException;
 import org.slf4j.Logger;
 
-import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import java.util.Comparator;
 
-import static org.apache.commons.collections4.ComparatorUtils.naturalComparator;
-import static org.apache.commons.collections4.ComparatorUtils.nullLowComparator;
-import static org.apache.commons.collections4.ComparatorUtils.reversedComparator;
-import static org.slf4j.LoggerFactory.getLogger;
-
 import static javax.jcr.PropertyType.*;
+import static org.apache.commons.collections4.ComparatorUtils.*;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Compares {@link javax.jcr.Value} as JCR Query does.
+ *
+ * @author Hans-Peter Stoerr
  */
 public class ValueComparatorFactory {
 

--- a/services/staging/src/test/java/com/composum/sling/platform/staging/query/QueryConditionDsl2Test.java
+++ b/services/staging/src/test/java/com/composum/sling/platform/staging/query/QueryConditionDsl2Test.java
@@ -30,6 +30,8 @@ import static org.junit.Assert.*;
 /**
  * Tests for {@link QueryConditionDsl}. TODO: check variable ranges; check whether = '' is the same as is null. check
  * null binding values - are they bound?
+ *
+ * @author Hans-Peter Stoerr
  */
 @RunWith(Parameterized.class)
 public class QueryConditionDsl2Test {
@@ -41,30 +43,31 @@ public class QueryConditionDsl2Test {
         return Arrays.asList(new Object[][]{
                 {builder().property("bla").eq().val("hallo").and()
                         .startGroup().lower().property("bla").eq().val(17).endGroup(),
-                        "n.[bla] = $val1 AND ( LOWER( n.[bla] ) = $val2 ) "},
-                {builder().lower().localName().eq().val("lcl"), "LOWER( LOCALNAME(n) ) = $val1 "},
+                        "n.[bla] = $nval1 AND ( LOWER( n.[bla] ) = $nval2 ) "},
+                {builder().lower().localName().eq().val("lcl"), "LOWER( LOCALNAME(n) ) = $nval1 "},
                 {builder().contains("test").and().score().gt().val(3),
-                        "CONTAINS(n.* , $val1 ) AND SCORE(n) > $val2 "},
+                        "CONTAINS(n.* , $nval1 ) AND SCORE(n) > $nval2 "},
                 {builder().contains("prop", "test").or().upper().name().neq().val("node"),
-                        "CONTAINS(n.[prop] , $val1 ) OR UPPER( NAME(n) ) <> $val2 "},
+                        "CONTAINS(n.[prop] , $nval1 ) OR UPPER( NAME(n) ) <> $nval2 "},
                 {builder().not().isNotNull("ha").or().not().startGroup().isChildOf("/somewhere"),
                         "NOT n.[ha] IS NOT NULL OR NOT ( ISCHILDNODE(n,'/somewhere' ) ) "},
                 {builder().isDescendantOf("/what").and().startGroup().isSameNodeAs("/where"),
                         "ISDESCENDANTNODE(n,'/what' ) AND ( ISSAMENODE(n,'/where' ) ) "},
                 {builder().isNull("that").and().startGroup().length("what").geq().val(17),
-                        "n.[that] IS NULL AND ( LENGTH(n.[what] ) >= $val1 ) "},
+                        "n.[that] IS NULL AND ( LENGTH(n.[what] ) >= $nval1 ) "},
                 {builder().property("that").gt().val(Double.MAX_VALUE).and().property("what").geq().val(Long.MAX_VALUE)
                         .and().property(JCR_PATH).like().val("/bla/%").and().property("p4").lt().val(Long.MIN_VALUE)
                         .and().property("p5").leq().val(Double.MIN_NORMAL)
                         .and().property("p6").eq().val(Calendar.getInstance())
                         .and().property("p7").neq().val(new URI("http://www.example.net/"))
-                        , "n.[that] > $val1 AND n.[what] >= $val2 AND n.[jcr:path] LIKE $val3 AND n.[p4] < $val4 AND " +
+                        , "n.[that] > $nval1 AND n.[what] >= $nval2 AND n.[jcr:path] LIKE $nval3 AND n.[p4] < $nval4 " +
+                        "AND " +
                         "n" +
-                        ".[p5] <= $val5 AND n.[p6] = $val6 AND n.[p7] <> $val7 "},
+                        ".[p5] <= $nval5 AND n.[p6] = $nval6 AND n.[p7] <> $nval7 "},
                 {builder().property("g1").eq().val(true).and().property("g2").neq().pathOf(resource)
                         .and().property("g3").gt().val(new BigDecimal(17))
                         .and().property("g4").eq().uuidOf(resource),
-                        "n.[g1] = $val1 AND n.[g2] <> $val2 AND n.[g3] > $val3 AND n.[g4] = $val4 "},
+                        "n.[g1] = $nval1 AND n.[g2] <> $nval2 AND n.[g3] > $nval3 AND n.[g4] = $nval4 "},
                 {QueryConditionDsl.fromString("CONTAINS(n.[*] , 'foo' ) AND ISCHILDNODE(n,'/somewhere' ) " +
                         "AND LOWER ( LOCALNAME(n) ) = 'bar' " +
                         "OR n.[jcr:created] > CAST('2008-01-01T00:00:00.000Z' AS DATE) "),
@@ -72,9 +75,10 @@ public class QueryConditionDsl2Test {
                                 "AND LOWER ( LOCALNAME(n) ) = 'bar' " +
                                 "OR n.[jcr:created] > CAST('2008-01-01T00:00:00.000Z' AS DATE) "},
                 {builder().in("prop", "hu", "ha", "ho"),
-                        "( n.[prop] = $val1 OR n.[prop] = $val2 OR n.[prop] = $val3 ) "},
+                        "( n.[prop] = $nval1 OR n.[prop] = $nval2 OR n.[prop] = $nval3 ) "},
                 {builder().property("a").eq().val("x").and().selector("m").localName().gt().val("b")
-                        .or().property("y").neq().val("c"), "n.[a] = $val1 AND LOCALNAME(m) > $val2 OR n.[y] <> $val3 "}
+                        .or().property("y").neq().val("c"), "n.[a] = $nval1 AND LOCALNAME(m) > $nval2 OR n.[y] <> " +
+                        "$nval3 "}
         });
     }
 


### PR DESCRIPTION
This contains some extensions of the staging.Query neccesary for CMP-38:

- provides a function Query.selectAndExecute to return various specified properties of the results (including pseudo-properties like jcr:path, jcr:score or rep:excerpt or oak:scoreExplanation

- provides limited join functionality for joins that find only the selected node or its descendants, and must not cross versionable nodes.

See also https://ist-software.atlassian.net/wiki/x/bA3YAg .